### PR TITLE
Modifying the Makefile to build testcases separately

### DIFF
--- a/LibOS/shim/test/ltp/Makefile
+++ b/LibOS/shim/test/ltp/Makefile
@@ -1,6 +1,10 @@
 include makevars.mk
 
-target = $(INSTALLDIR)/INSTALL_SUCCESS build-manifest
+ifeq ($(TESTDIR), "")
+	target = src-configure build-ltp link-pal build-manifest
+else
+	target = src-configure build-lib build-test link-pal build-manifest
+endif
 exec_target =
 
 clean-extra += clean-build
@@ -18,32 +22,56 @@ endif
 $(SRCDIR)/Makefile:
 	$(error "$(SRCDIR) is empty. Please run `git submodule update --init $(SRCDIR)` or download the LTP source code (https://github.com/linux-test-project/ltp) into $(SRCDIR).")
 
-$(SRCDIR)/configure: $(SRCDIR)/Makefile
+.PHONY: make-autotools
+make-autotools: $(SRCDIR)/Makefile
 	$(MAKE) -C $(SRCDIR) autotools
 
-.SECONDARY: $(BUILDDIR)/BUILD_SUCCESS
-$(BUILDDIR)/BUILD_SUCCESS: $(SRCDIR)/configure
+.PHONY: src-configure
+src-configure: make-autotools
 	# Out-of-tree build steps were taken from ltp/INSTALL.
 	# The instructions below assume that SRCDIR and BUILDDIR are absolute.
 	mkdir -p $(BUILDDIR)
+	mkdir -p $(INSTALLDIR)
 	# Kernel module tests are not meaningful for our LibOS and building them causes troubles on
 	# incompatible host kernels.
 	cd $(BUILDDIR) && $(SRCDIR)/configure --without-modules --prefix $(INSTALLDIR)
-	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
-	touch $@
 
-.SECONDARY: $(INSTALLDIR)/INSTALL_SUCCESS
-$(INSTALLDIR)/INSTALL_SUCCESS: $(BUILDDIR)/BUILD_SUCCESS
+.PHONY: build-ltp
+build-ltp: 
+	mkdir -p $(BUILDDIR)
+	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
+	touch $(BUILDDIR)/BUILD_SUCCESS.txt
 	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) SKIP_IDCHECK=1 install
+	touch $(INSTALLDIR)/INSTALL_SUCCESS.txt
+
+.PHONY: build-lib
+build-lib: 
+	$(MAKE) -C $(BUILDDIR)/lib -f $(SRCDIR)/lib/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
+	touch $(BUILDDIR)/BUILD_SUCCESS.txt
+
+.PHONY: build-test
+build-test:
+	mkdir -p $(BUILDDIR)/$(TESTDIR)
+	mkdir -p $(TESTCASEDIR)
+	$(MAKE) -C $(BUILDDIR)/$(TESTDIR) -f $(SRCDIR)/$(TESTDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
+	$(MAKE) -C $(BUILDDIR)/$(TESTDIR) -f $(SRCDIR)/$(TESTDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) SKIP_IDCHECK=1 install
+	touch $(INSTALLDIR)/INSTALL_SUCCESS.txt
+
+.PHONY: clean-test
+clean-test:
+	$(MAKE) -C $(BUILDDIR)/$(TESTDIR) -f $(SRCDIR)/$(TESTDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) clean
+
+.PHONY: link-pal
+link-pal:
 	ln -sf $(call relative-to,$(TESTCASEDIR),../../../Runtime/pal_loader) $(TESTCASEDIR)/pal_loader
 	ln -sf $(abspath Makefile.testcases) $(TESTCASEDIR)/Makefile
-	touch $@
 
 .PHONY: build-manifest
-build-manifest: $(TESTCASEDIR)/manifest.template $(INSTALLDIR)/INSTALL_SUCCESS
+build-manifest: $(TESTCASEDIR)/manifest.template
 	$(MAKE) -C $(TESTCASEDIR)
 
-$(TESTCASEDIR)/manifest.template: manifest.template $(INSTALLDIR)/INSTALL_SUCCESS
+
+$(TESTCASEDIR)/manifest.template: manifest.template
 	sed -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$< > $@
 
@@ -64,7 +92,7 @@ endif
 ltp.xml: CFG = ltp.cfg
 ltp-sgx.xml: CFG = ltp.cfg ltp-sgx.cfg ltp-bug-1075.cfg
 
-%.xml: $(CFG) $(target) $(INSTALLDIR)/INSTALL_SUCCESS
+%.xml: $(CFG) $(LTPSCENARIO) $(target)
 	./contrib/conf_lint.py $(CFG) --scenario $(LTPSCENARIO)
 	./runltp_xml.py $(RUNLTPOPTS) $(foreach cfg,$(CFG),-c $(cfg)) $(LTPSCENARIO) -O $@
 

--- a/LibOS/shim/test/ltp/makevars.mk
+++ b/LibOS/shim/test/ltp/makevars.mk
@@ -7,3 +7,4 @@ INSTALLDIR = $(ROOTDIR)/install
 TESTCASEDIR = $(INSTALLDIR)/testcases/bin
 LTPSCENARIO = $(INSTALLDIR)/runtest/syscalls
 RUNLTPOPTS =
+TESTDIR = ""


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR should should help us build a single ltp test instead of whole LTP suite if TESTDIR is defined
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
How to specify TestDir
TESTDIR = testcases/kernel/syscalls/access (TestPath from ltp project)

If build and install folders are not present and you want to specifically build single test
     Specify the TESTDIR in makevars.mk and run make all

If you want to build specific test
     make  build-test

To Clean the test:
      make  clean-test

To build only libraries
      make  build-lib

To build whole ltp suite
      Don't specify TESTDIR in makevars.mk and run make  all
